### PR TITLE
Fix compilation

### DIFF
--- a/beefy-gadget/rpc/src/notification.rs
+++ b/beefy-gadget/rpc/src/notification.rs
@@ -31,7 +31,7 @@ impl SignedCommitment {
 	) -> Self
 	where
 		Block: BlockT,
-		Signature: Encode,
+		Signature: Encode + Clone, // TODO This `Clone` bound should not be necessary.
 	{
 		SignedCommitment(signed_commitment.encode().into())
 	}


### PR DESCRIPTION
Note that you can avoid `Clone` requirement if we hold `Vec<&'a Signature>` in the temporary commitment - that's enough for serializing.